### PR TITLE
add ec2:GetSecurityGroupsForVpc permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,7 @@ resource "aws_iam_policy" "this" {
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",


### PR DESCRIPTION
Fixes the Unauthorized issue when the polygon load balancers need to be changed

```
> kubernetes_service_v1.polygon_vpc_endpoint: Destroying... [id=polygon-service/polygon-vpc-endpoint]
> kubernetes_service_v1.polygon_external[0]: Destroying... [id=polygon-service/polygon-external]
> 
> Error: Unauthorized
> 
> 
> Error: Unauthorized
```